### PR TITLE
add: 初期バージョンのDTO、スキーマ、イベントを定義

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,9 @@
     },
     "packages/shared": {
       "name": "@chao-game-online/shared",
+      "dependencies": {
+        "zod": "^3.25.73",
+      },
       "devDependencies": {
         "@types/bun": "latest",
       },
@@ -459,6 +462,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@3.25.73", "", {}, "sha512-fuIKbQAWQl22Ba5d1quwEETQYjqnpKVyZIWAhbnnHgnDd3a+z4YgEfkI5SZ2xMELnLAXo/Flk2uXgysZNf0uaA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,5 +15,8 @@
 	},
 	"peerDependencies": {
 		"typescript": "^5"
+	},
+	"dependencies": {
+		"zod": "^3.25.73"
 	}
 }

--- a/packages/shared/src/core.ts
+++ b/packages/shared/src/core.ts
@@ -1,0 +1,9 @@
+export enum GameType {
+	"four-reversi",
+	"four-gomoku",
+}
+
+export const GameTypeNames: Record<GameType, string> = {
+	[GameType["four-reversi"]]: "四人リバーシ",
+	[GameType["four-gomoku"]]: "四人五目並べ",
+};

--- a/packages/shared/src/dtos.ts
+++ b/packages/shared/src/dtos.ts
@@ -1,0 +1,23 @@
+import type { GameType } from "./core";
+
+export type RoomInfoDto = {
+	number: number;
+	name: string;
+	gameType: GameType;
+	playerCount: number;
+	maxPlayerCount: number;
+};
+
+export type PlayerDto = {
+	id: string;
+	displayName: string;
+	isHost: boolean;
+};
+
+export type RoomStateDto = {
+	number: number;
+	name: string;
+	gameType: GameType;
+	players: PlayerDto[];
+	maxPlayerCount: number;
+};

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -1,0 +1,25 @@
+import type { RoomInfoDto, RoomStateDto } from "./dtos";
+import type { CreateRoomPayload, JoinRoomPayload } from "./schemas";
+
+export type AckResponse<T = void> =
+	| {
+			success: true;
+			data: T;
+	  }
+	| {
+			success: false;
+			error: string;
+	  };
+
+export interface ClientToServerEvents {
+	"lobby:create": (payload: CreateRoomPayload, ack: (res: AckResponse<RoomStateDto>) => void) => void;
+	"lobby:join": (payload: JoinRoomPayload, ack: (res: AckResponse<RoomStateDto>) => void) => void;
+
+	"room:leave": (ack: (res: AckResponse) => void) => void;
+}
+
+export interface ServerToClientEvents {
+	"lobby:rooms_updated": (rooms: RoomInfoDto[]) => void;
+
+	"room:updated": (room: RoomStateDto) => void;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,0 @@
-export const message = "Hello from shared package!";

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from "./lobby.schema";

--- a/packages/shared/src/schemas/lobby.schema.ts
+++ b/packages/shared/src/schemas/lobby.schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { GameType } from "../core";
+
+// ルーム作成
+export const CreateRoomSchema = z.object({
+	name: z
+		.string({ required_error: "ルーム名を入力してください" })
+		.min(3, "ルーム名は3文字以上で入力してください")
+		.max(20, "ルーム名は20文字以下で入力してください"),
+	GameType: z.nativeEnum(GameType, {
+		required_error: "ゲームを選択してください",
+		invalid_type_error: "有効なゲームを選択してください",
+	}),
+});
+export type CreateRoomPayload = z.infer<typeof CreateRoomSchema>;
+
+// ルーム入室
+export const JoinRoomSchema = z.object({
+	roomNumber: z
+		.number({ required_error: "ルーム番号を入力してください" })
+		.min(10000, "ルーム番号は5桁の正の整数で指定してください")
+		.max(99999, "ルーム番号は5桁の正の整数で指定してください"),
+});
+export type JoinRoomPayload = z.infer<typeof JoinRoomSchema>;


### PR DESCRIPTION
## 概要

MVPであるルーム機能を実現するため、クライアントとサーバーで共通利用する型定義の土台を実装しました。

---

## 変更内容

- [x] DTOの定義（`RoomInfoDto`, `PlayerDto` など）
- [x] ドメインモデルの定義（`GameType` enum）
- [x] Zodによるバリデーションスキーマの定義
- [x] Socket.IOのイベントインターフェースを定義
- [x] 汎用的なAckレスポンス型を定義

---

## 備考

- このPRは型定義のみで、ロジックの実装は含みません。

---