### PR TITLE
feat(client): zustandを用いた認証とSocket接続の仕組みを構築

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.11",
         "zod": "^3.25.74",
+        "zustand": "^5.0.6",
       },
       "devDependencies": {
         "@types/react": "^19.1.8",
@@ -1044,6 +1045,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@3.25.74", "", {}, "sha512-J8poo92VuhKjNknViHRAIuuN6li/EwFbAC8OedzI8uxpEPGiXHGQu9wemIAioIpqgfB4SySaJhdk0mH5Y4ICBg=="],
+
+    "zustand": ["zustand@5.0.6", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -4,3 +4,5 @@ VITE_APP_FIREBASE_PROJECT_ID=test_project_id
 VITE_APP_FIREBASE_STORAGE_BUCKET=test_storage_bucket
 VITE_APP_FIREBASE_MESSAGING_SENDER_ID=test_messaging_sender_id
 VITE_APP_FIREBASE_APP_ID=test_app_id
+
+VITE_APP_SOCKET_URL=http://localhost:3001

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,8 @@
 		"socket.io-client": "^4.8.1",
 		"tailwind-merge": "^3.3.1",
 		"tailwindcss": "^4.1.11",
-		"zod": "^3.25.74"
+		"zod": "^3.25.74",
+		"zustand": "^5.0.6"
 	},
 	"devDependencies": {
 		"@types/react": "^19.1.8",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
+import { useAuthStore } from "./features/auth/useAuthStore";
+import { useAuthSocketSync } from "./hooks/useAuthSocketSync";
+import { AuthPage } from "./pages/AuthPage";
+
+const router = createBrowserRouter([
+	{
+		path: "/",
+		element: <AuthPage />,
+	},
+]);
+
+export const App = () => {
+	// アプリケーション起動時に認証状態の監視を開始
+	useEffect(() => {
+		const unsubscribe = useAuthStore.getState().initialize();
+		return () => unsubscribe(); // クリーンアップ
+	}, []);
+
+	// 認証とSocket接続を同期
+	useAuthSocketSync();
+
+	return <RouterProvider router={router} />;
+};

--- a/packages/client/src/features/auth/AuthForm.tsx
+++ b/packages/client/src/features/auth/AuthForm.tsx
@@ -1,4 +1,4 @@
-import { createUserWithEmailAndPassword, signInWithEmailAndPassword, updateProfile, getIdToken } from "firebase/auth";
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { auth } from "@/services/firebase";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -44,13 +44,12 @@ export const AuthForm = () => {
 
 	const handleLogin = async (data: LoginFormData) => {
 		try {
-			const userCredential = await signInWithEmailAndPassword(auth, data.email, data.password);
-			const idToken = await getIdToken(userCredential.user);
-			console.log("ログイン成功:", { user: userCredential.user });
-			console.log("ID Token:", idToken);
-			alert("ログインに成功しました！コンソールを確認してください。");
+			await signInWithEmailAndPassword(auth, data.email, data.password);
+
+			alert("ログインに成功しました！");
 		} catch (error) {
 			console.error("ログインエラー:", error);
+
 			alert("ログインに失敗しました。");
 		}
 	};
@@ -59,10 +58,8 @@ export const AuthForm = () => {
 		try {
 			const userCredential = await createUserWithEmailAndPassword(auth, data.email, data.password);
 			await updateProfile(userCredential.user, { displayName: data.displayName });
-			const idToken = await getIdToken(userCredential.user);
-			console.log("新規登録成功:", { user: userCredential.user });
-			console.log("ID Token:", idToken);
-			alert("新規登録に成功しました！コンソールを確認してください。");
+
+			alert("新規登録に成功しました！");
 		} catch (error) {
 			console.error("新規登録エラー:", error);
 			alert("新規登録に失敗しました。");

--- a/packages/client/src/features/auth/useAuthStore.ts
+++ b/packages/client/src/features/auth/useAuthStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { onAuthStateChanged, getIdToken, type User } from "firebase/auth";
+import { auth } from "@/services/firebase";
+
+type AuthState = {
+	isLoading: boolean;
+	user: User | null;
+	idToken: string | null;
+	initialize: () => () => void; // Unsubscribeを返す
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+	isLoading: true,
+	user: null,
+	idToken: null,
+	initialize: () => {
+		const unsubscribe = onAuthStateChanged(auth, async (user) => {
+			if (user) {
+				const token = await getIdToken(user);
+				set({ user, idToken: token, isLoading: false });
+			} else {
+				set({ user: null, idToken: null, isLoading: false });
+			}
+		});
+		return unsubscribe;
+	},
+}));

--- a/packages/client/src/hooks/useAuthSocketSync.ts
+++ b/packages/client/src/hooks/useAuthSocketSync.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useAuthStore } from "@/features/auth/useAuthStore";
+import { useSocketStore } from "@/services/socket/useSocketStore";
+
+export const useAuthSocketSync = () => {
+	const { idToken } = useAuthStore();
+	const { connect, disconnect, isConnected } = useSocketStore();
+
+	useEffect(() => {
+		if (idToken && !isConnected) {
+			// ログイン状態（idTokenあり）かつ未接続なら接続
+			connect(idToken);
+		} else if (!idToken && isConnected) {
+			// ログアウト状態（idTokenなし）かつ接続中なら切断
+			disconnect();
+		}
+	}, [idToken, isConnected, connect, disconnect]);
+};

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,13 +1,29 @@
-import { StrictMode } from "react";
+import { StrictMode, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import "./global.css";
 import { AuthPage } from "./pages/AuthPage";
+import { useAuthStore } from "./features/auth/useAuthStore";
+import { useAuthSocketSync } from "./hooks/useAuthSocketSync";
+
+// アプリケーションのメインコンポーネント
+const App = () => {
+	// アプリケーション起動時に認証状態の監視を開始
+	useEffect(() => {
+		const unsubscribe = useAuthStore.getState().initialize();
+		return () => unsubscribe(); // クリーンアップ関数
+	}, []);
+
+	// 認証とSocket接続を同期するフックを呼び出す
+	useAuthSocketSync();
+
+	return <RouterProvider router={router} />;
+};
 
 const router = createBrowserRouter([{ path: "/", element: <AuthPage /> }]);
 
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>
-		<RouterProvider router={router} />
+		<App />
 	</StrictMode>
 );

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,26 +1,7 @@
-import { StrictMode, useEffect } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { App } from "./App";
 import "./global.css";
-import { AuthPage } from "./pages/AuthPage";
-import { useAuthStore } from "./features/auth/useAuthStore";
-import { useAuthSocketSync } from "./hooks/useAuthSocketSync";
-
-// アプリケーションのメインコンポーネント
-const App = () => {
-	// アプリケーション起動時に認証状態の監視を開始
-	useEffect(() => {
-		const unsubscribe = useAuthStore.getState().initialize();
-		return () => unsubscribe(); // クリーンアップ関数
-	}, []);
-
-	// 認証とSocket接続を同期するフックを呼び出す
-	useAuthSocketSync();
-
-	return <RouterProvider router={router} />;
-};
-
-const router = createBrowserRouter([{ path: "/", element: <AuthPage /> }]);
 
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>

--- a/packages/client/src/services/socket/useSocketStore.ts
+++ b/packages/client/src/services/socket/useSocketStore.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import { io, type Socket } from "socket.io-client";
+import type { ServerToClientEvents, ClientToServerEvents } from "@chao-game-online/shared/events"; //
+
+type SocketState = {
+	socket: Socket<ServerToClientEvents, ClientToServerEvents> | null;
+	isConnected: boolean;
+	connect: (token: string) => void;
+	disconnect: () => void;
+};
+
+const SOCKET_URL = import.meta.env.VITE_APP_SOCKET_URL;
+
+export const useSocketStore = create<SocketState>((set) => ({
+	socket: null,
+	isConnected: false,
+	connect: (token) => {
+		const newSocket = io(SOCKET_URL, {
+			auth: { token },
+			transports: ["websocket"],
+		});
+
+		newSocket.on("connect", () => {
+			set({ isConnected: true });
+			console.log("Socket.IO connected!");
+		});
+
+		newSocket.on("disconnect", () => {
+			set({ isConnected: false });
+			console.log("Socket.IO disconnected.");
+		});
+
+		set({ socket: newSocket });
+	},
+	disconnect: () => {
+		set((state) => {
+			state.socket?.disconnect();
+			return { socket: null, isConnected: false };
+		});
+	},
+}));

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -7,6 +7,8 @@ interface ImportMetaEnv {
 	readonly VITE_APP_FIREBASE_STORAGE_BUCKET: string;
 	readonly VITE_APP_FIREBASE_MESSAGING_SENDER_ID: string;
 	readonly VITE_APP_FIREBASE_APP_ID: string;
+
+	readonly VITE_APP_SOCKET_URL: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
クライアント側の認証情報とSocket.IO接続の管理機能を実装しました。

**実装内容:**

  - **認証・Socket状態管理の実装 (zustand)**

      - `zustand` を導入し、アプリケーション全体の状態管理を簡素化しました。
      - Firebaseの認証状態（ユーザー情報、IDトークン）を管理する `useAuthStore` を作成しました。
      - Socket.IOのインスタンスと接続状態を管理する `useSocketStore` を作成しました。

  - **認証状態とSocket接続の同期**

      - ログイン状態（IDトークン取得）をトリガーに、自動でSocket.IOサーバーへ接続するカスタムフック `useAuthSocketSync` を実装しました。
      - ログアウト時には、自動で切断処理が実行されます。

  - **既存コンポーネントの修正**

      - `AuthForm`コンポーネントからIDトークン取得などのロジックを分離し、状態ストアに一任することで、コンポーネントの責務を単一にしました。

**レビューのポイント:**

  - `CONTRIBUTING.md` のガイドラインに準拠しているか
  - 導入した `zustand` のストア設計に問題がないか
  - 認証状態の変更に伴い、Socket接続/切断が意図通りに実行されるか