### PR TITLE
feat: ルーム機能の追加と認証バグの修正

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from "./features/auth/useAuthStore";
 import { useAuthSocketSync } from "./hooks/useAuthSocketSync";
 import { AuthPage } from "./pages/AuthPage";
 import { LobbyPage } from "./pages/LobbyPage";
+import { RoomPage } from "./pages/RoomPage";
 import { useSocketStore } from "./services/socket/useSocketStore";
 
 /**
@@ -61,6 +62,14 @@ const router = createBrowserRouter([
 				element: (
 					<ProtectedRoute>
 						<LobbyPage />
+					</ProtectedRoute>
+				),
+			},
+			{
+				path: "/room/:roomNumber",
+				element: (
+					<ProtectedRoute>
+						<RoomPage />
 					</ProtectedRoute>
 				),
 			},

--- a/packages/client/src/features/auth/AuthForm.tsx
+++ b/packages/client/src/features/auth/AuthForm.tsx
@@ -59,6 +59,9 @@ export const AuthForm = () => {
 			const userCredential = await createUserWithEmailAndPassword(auth, data.email, data.password);
 			await updateProfile(userCredential.user, { displayName: data.displayName });
 
+			// ★ 変更点: IDトークンを強制的に更新し、`onIdTokenChanged`リスナーを発火させる
+			await userCredential.user.getIdToken(true);
+
 			alert("新規登録に成功しました！");
 		} catch (error) {
 			console.error("新規登録エラー:", error);

--- a/packages/client/src/features/auth/useAuthStore.ts
+++ b/packages/client/src/features/auth/useAuthStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { onAuthStateChanged, getIdToken, type User } from "firebase/auth";
+import { getIdToken, type User, onIdTokenChanged } from "firebase/auth";
 import { auth } from "@/services/firebase";
 
 type AuthState = {
@@ -14,7 +14,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 	user: null,
 	idToken: null,
 	initialize: () => {
-		const unsubscribe = onAuthStateChanged(auth, async (user) => {
+		const unsubscribe = onIdTokenChanged(auth, async (user) => {
 			if (user) {
 				const token = await getIdToken(user);
 				set({ user, idToken: token, isLoading: false });

--- a/packages/client/src/features/lobby/CreateRoomModal.tsx
+++ b/packages/client/src/features/lobby/CreateRoomModal.tsx
@@ -9,10 +9,14 @@ import { useLobbyStore } from "./useLobbyStore";
 import { GameType, GameTypeNames } from "@chao-game-online/shared/core";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useState } from "react";
+import { useRoomStore } from "../room/useRoomStore";
+import { useNavigate } from "react-router-dom";
 
 export const CreateRoomModal = () => {
 	const [isOpen, setIsOpen] = useState(false);
 	const { createRoom } = useLobbyStore();
+	const { setRoom } = useRoomStore();
+	const navigate = useNavigate();
 
 	const form = useForm<CreateRoomPayload>({
 		resolver: zodResolver(CreateRoomSchema),
@@ -25,9 +29,9 @@ export const CreateRoomModal = () => {
 	const onSubmit = (data: CreateRoomPayload) => {
 		createRoom(data, (res) => {
 			if (res.success) {
-				alert(`ルーム「${res.data?.name}」を作成しました`);
+				setRoom(res.data); // ルーム情報をストアに保存
 				setIsOpen(false);
-				// TODO: 作成したルーム画面に遷移
+				navigate(`/room/${res.data.number}`); // ルーム画面へ遷移
 			} else {
 				alert(`ルームの作成に失敗しました: ${res.error}`);
 			}

--- a/packages/client/src/features/room/useRoomStore.ts
+++ b/packages/client/src/features/room/useRoomStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import type { RoomStateDto } from "@chao-game-online/shared/dtos";
+import { useSocketStore } from "@/services/socket/useSocketStore";
+
+type RoomState = {
+	room: RoomStateDto | null;
+	setRoom: (room: RoomStateDto | null) => void;
+	leaveRoom: (callback: () => void) => void;
+};
+
+export const useRoomStore = create<RoomState>((set) => ({
+	room: null,
+	setRoom: (room) => set({ room }),
+	leaveRoom: (callback) => {
+		const { socket } = useSocketStore.getState();
+		if (!socket) return alert("ソケットが接続されていません");
+
+		// サーバーに room:leave イベントを送信
+		socket.emit("room:leave", (res) => {
+			if (res.success) {
+				set({ room: null }); // ストアのルーム情報をクリア
+				callback(); // 成功時のコールバックを実行
+			} else {
+				alert(`ルームの退室に失敗しました: ${res.error}`);
+			}
+		});
+	},
+}));

--- a/packages/client/src/pages/LobbyPage.tsx
+++ b/packages/client/src/pages/LobbyPage.tsx
@@ -7,10 +7,14 @@ import { RoomList } from "@/features/lobby/RoomList";
 import { Button } from "@/components/ui/button";
 import { signOut } from "firebase/auth";
 import { auth } from "@/services/firebase";
+import { useRoomStore } from "@/features/room/useRoomStore";
+import { useNavigate } from "react-router-dom";
 
 export const LobbyPage = () => {
 	const { socket } = useSocketStore();
 	const { rooms, setRooms, joinRoom } = useLobbyStore();
+	const { setRoom } = useRoomStore();
+	const navigate = useNavigate();
 
 	useEffect(() => {
 		if (!socket) return;
@@ -31,8 +35,8 @@ export const LobbyPage = () => {
 	const handleJoinRoom = (roomNumber: number) => {
 		joinRoom({ roomNumber }, (res) => {
 			if (res.success) {
-				alert(`ルーム ${res.data?.number} に参加しました`);
-				// TODO: ルーム画面に遷移する処理
+				setRoom(res.data); // ルーム情報をストアに保存
+				navigate(`/room/${res.data.number}`); // ルーム画面へ遷移
 			} else {
 				alert(`ルームへの参加に失敗しました: ${res.error}`);
 			}

--- a/packages/client/src/pages/RoomPage.tsx
+++ b/packages/client/src/pages/RoomPage.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useRoomStore } from "@/features/room/useRoomStore";
+import { useSocketStore } from "@/services/socket/useSocketStore";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import type { RoomStateDto } from "@chao-game-online/shared/dtos";
+
+export const RoomPage = () => {
+	const navigate = useNavigate();
+	const { roomNumber } = useParams<{ roomNumber: string }>();
+	const { socket } = useSocketStore();
+	const { room, setRoom, leaveRoom } = useRoomStore();
+
+	useEffect(() => {
+		if (!socket) return;
+
+		// サーバーからルーム情報更新イベントを受け取る
+		const handleRoomUpdated = (updatedRoom: RoomStateDto) => {
+			// このルームの情報であれば更新
+			if (String(updatedRoom.number) === roomNumber) {
+				setRoom(updatedRoom);
+			}
+		};
+
+		socket.on("room:updated", handleRoomUpdated);
+
+		// コンポーネントのアンマウント時にイベントリスナーを解除
+		return () => {
+			socket.off("room:updated", handleRoomUpdated);
+		};
+	}, [socket, setRoom, roomNumber]);
+
+	const handleLeaveRoom = () => {
+		leaveRoom(() => {
+			alert("ルームから退室しました。");
+			navigate("/lobby"); // ロビー画面へ遷移
+		});
+	};
+
+	if (!room) {
+		return <div className="container mx-auto p-4">ルーム情報を読み込み中...</div>;
+	}
+
+	return (
+		<div className="container mx-auto p-4">
+			<header className="flex justify-between items-center mb-4">
+				<h1 className="text-2xl font-bold">
+					ルーム: {room.name} (#{room.number})
+				</h1>
+				<Button onClick={handleLeaveRoom} variant="outline">
+					退室する
+				</Button>
+			</header>
+			<main>
+				<Card>
+					<CardHeader>
+						<CardTitle>参加者一覧</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>プレイヤー名</TableHead>
+									<TableHead>役割</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{room.players.map((player) => (
+									<TableRow key={player.id}>
+										<TableCell>{player.displayName}</TableCell>
+										<TableCell>{player.isHost ? "ホスト" : "ゲスト"}</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</CardContent>
+				</Card>
+			</main>
+		</div>
+	);
+};


### PR DESCRIPTION
## 概要

プロジェクト引継ぎ資料に基づき、ルーム機能の基本UIを実装しました。
また、実装中に発見した新規登録時の認証バグを併せて修正しています。

## 実装内容

### 機能追加 (`add: ルーム機能のUIと基本ロジックを追加`)

- **ページ/ルーティング設定**
    - `/room/:roomNumber` ルートと `RoomPage` コンポーネントを作成
    - ルーム作成・参加後に該当のルーム画面へ遷移するように修正
- **状態管理/UI実装**
    - ルーム情報を管理する `useRoomStore` を作成
    - `room:updated` イベントを購読し、参加者一覧をリアルタイムで表示
    - 退室ボタンを実装し、押下時に `room:leave` イベントを送信後、ロビーへ遷移

### バグ修正 (`fix: 新規登録時に表示名が設定されないバグを修正`)

- **原因**
    - 新規登録時に、Firebaseの表示名(`displayName`)がIDトークンに反映される前にSocket接続が開始され、サーバー側で表示名が取得できていなかった。
- **対応**
    - 認証状態の監視を `onAuthStateChanged` から `onIdTokenChanged` に変更。
    - 新規登録処理の最後に `user.getIdToken(true)` を実行し、IDトークンを強制的に更新するよう修正。

## 確認事項

- [x] ルーム作成後、ルーム画面に遷移すること
- [x] ルーム参加後、ルーム画面に遷移すること
- [x] 他のブラウザで同じルームに参加すると、参加者一覧がリアルタイムで更新されること
- [x] 退室ボタンを押すと、ロビー画面に戻ること
- [x] 新規登録したユーザーの表示名が、ルーム参加時に正しく表示されること